### PR TITLE
Fix moderator email

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -134,7 +134,7 @@ class YellowComments {
 
     // Return Email
     function getEmail() {
-        return $this->yellow->page->get("moderator") ? $this->yellow->page->get("moderator") : ($this->yellow->config->isExisting("commentsModerator") ? $this->yellow->config->get("commentsModerator") : $this->yellow->config->get("author"));
+        return $this->yellow->page->get("moderator") ? $this->yellow->page->get("moderator") : ($this->yellow->config->isExisting("commentsModerator") ? $this->yellow->config->get("commentsModerator") : $this->yellow->config->get("email"));
     }
 
     // Return file name from page object


### PR DESCRIPTION
If commentModerator is not present, site email should be used, not site author as this only contains the site author's name.